### PR TITLE
Remove .npmrc

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,8 +6,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    env:
-      NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     permissions:
       contents: read

--- a/.github/workflows/generate-code.yml
+++ b/.github/workflows/generate-code.yml
@@ -5,8 +5,6 @@ on:
 jobs:
   generate-codes:
     runs-on: ubuntu-latest
-    env:
-      NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
       - name: Checkout 🛎️

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,8 +6,6 @@ jobs:
   build:
     name: Test PR
     runs-on: ubuntu-latest
-    env:
-      NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     permissions:
       contents: write

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-@agoraio-extensions:registry=https://npm.pkg.github.com


### PR DESCRIPTION
Since all the `@agoraio-extensions` related repositories are open sources, it's not necessary to configure the auth in the `.npmrc` now.